### PR TITLE
Fix ci.yaml workflows: uses new versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.17
+        go-version: "1.20"
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: go build cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         path: |
@@ -48,14 +48,17 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         distribution: goreleaser
-        version: latest
-        args: release --snapshot --skip-publish --rm-dist
+        version: v2.12.0
+        args: release --snapshot
+      env:
+        GORELEASER_SKIP_PUBLISH: true
     - name: Publish release (GoReleaser)
       if: startsWith(github.ref, 'refs/tags/')
       uses: goreleaser/goreleaser-action@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GORELEASER_SKIP_PUBLISH: true
       with:
         distribution: goreleaser
-        version: latest
-        args: release --rm-dist
+        version: v2.12.0
+        args: release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,9 @@
+version: 2
+
 builds:
-  - goos:
+  - id: win
+    goos:
       - windows
     ldflags:
       - -H=windowsgui
-archives:
-- format: binary
-  name_template: "{{ .ProjectName }}-{{ .Arch }}-v{{.Version}}"
-  replacements:
-    386: x86
-    amd64: x64
+    binary: "{{ .ProjectName }}-{{- if eq .Arch \"386\" }}x86{{ else if eq .Arch \"amd64\" }}x64{{ else }}{{ .Arch }}{{ end }}-v{{ .Version }}"


### PR DESCRIPTION
::set-output name is no longer valid.
release --snapshot --skip-publish --rm-dist is no longer valid.
goreleaser has moved to v2 format.

I think this makes the workflow works... but I'm not quite sure how to verify this. I have these files at this version in my main branch and it certainly works there.